### PR TITLE
docs: Restructure README — setup front and centre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,168 @@
 # Claude Cortex 🧠
 
-**Brain-like memory system for Claude Code** - Solves the context compaction and memory persistence problems.
+**Brain-like memory system for Claude Code** — Solves context compaction and memory persistence.
 
-## The Problem
-
-Claude Code has fundamental limitations:
-
-1. **Context Window Exhaustion** - Long sessions hit token limits
-2. **Compaction Loss** - When context is summarized, important details are lost
-3. **No Persistence** - Knowledge doesn't survive across sessions
-
-## The Solution
-
-Claude Cortex works like a human brain:
-
-- **Short-term memory** - Session-level, high detail, decays fast
-- **Long-term memory** - Cross-session, consolidated, persists
-- **Episodic memory** - Specific events and successful patterns
-- **Salience detection** - Automatically identifies what's worth remembering
-- **Temporal decay** - Memories fade but can be reinforced through access
-- **Consolidation** - Like sleep, moves worthy memories to long-term storage
+Claude Code forgets everything when context compacts or sessions end. Cortex fixes that with automatic memory extraction, temporal decay, and consolidation — like a human brain.
 
 ## Quick Start
 
-### 1. Install
-
-**Option A: Install via npm (Recommended)**
-
 ```bash
+# Step 1: Install
 npm install -g claude-cortex
+
+# Step 2: Configure hooks + Claude Code (REQUIRED — this makes memory automatic)
+npx claude-cortex setup
+
+# Step 3: Restart Claude Code and approve the MCP server when prompted
 ```
 
-**Option B: Use with npx (no install)**
+**That's it.** Cortex now automatically:
+- 📥 **Loads context** when a session starts
+- 🧠 **Saves important content** before compaction (decisions, fixes, learnings)
+- 💾 **Extracts knowledge** when a session ends
 
-Configure directly in `.mcp.json` (see step 2).
+You don't need to manually "remember" anything. The hooks handle it.
 
-**Option C: From source**
+> **Verify your install:** Run `npx claude-cortex doctor` to check everything is configured correctly.
+
+## How It Works
+
+### Automatic Memory (via Hooks)
+
+When you run `npx claude-cortex setup`, three hooks are installed:
+
+| Hook | Fires When | What It Does |
+|------|-----------|--------------|
+| **SessionStart** | Session begins | Loads project context from memory |
+| **PreCompact** | Before context compaction | Extracts important content before it's lost |
+| **SessionEnd** | Session exits | Saves decisions, fixes, and learnings |
+
+**What gets auto-extracted:**
+- Decisions: "decided to...", "going with...", "chose..."
+- Error fixes: "fixed by...", "the solution was...", "root cause..."
+- Learnings: "learned that...", "discovered...", "turns out..."
+- Architecture: "the architecture uses...", "design pattern..."
+- Preferences: "always...", "never...", "prefer to..."
+
+### Brain-Like Memory Model
+
+Cortex doesn't just store text — it thinks like a brain:
+
+- **Short-term memory** — Session-level, high detail, decays fast
+- **Long-term memory** — Cross-session, consolidated, persists
+- **Episodic memory** — Specific events and successful patterns
+- **Salience detection** — Automatically scores what's worth keeping
+- **Temporal decay** — Memories fade but reinforce through access
+- **Consolidation** — Worthy short-term memories promote to long-term
+
+### Salience Detection
+
+Not everything is worth remembering. The system scores content automatically:
+
+| Factor | Weight | Example |
+|--------|--------|---------|
+| Explicit request | 1.0 | "Remember this" |
+| Architecture decision | 0.9 | "We're using microservices" |
+| Error resolution | 0.8 | "Fixed by updating X" |
+| Code pattern | 0.7 | "Use this approach for auth" |
+| User preference | 0.7 | "Always use strict mode" |
+
+### Temporal Decay
+
+Like human memory, unused memories fade:
+
+```
+score = base_salience × (0.995 ^ hours_since_access)
+```
+
+Each access boosts the score by 1.2×. Frequently accessed short-term memories consolidate into long-term storage.
+
+## Tools
+
+Cortex provides these MCP tools to Claude Code:
+
+| Tool | Description |
+|------|-------------|
+| `remember` | Manually store a memory (optional — hooks do this automatically) |
+| `recall` | Search memories by query, category, or tags |
+| `forget` | Delete memories (with safety confirmations) |
+| `get_context` | Get relevant project context — key after compaction |
+| `start_session` / `end_session` | Session lifecycle management |
+| `consolidate` | Manually trigger memory consolidation |
+| `memory_stats` | View memory statistics |
+| `export_memories` / `import_memories` | Backup and restore |
+
+### MCP Resources
+
+| Resource | Description |
+|----------|-------------|
+| `memory://context` | Current memory context summary |
+| `memory://important` | High-priority memories |
+| `memory://recent` | Recently accessed memories |
+
+## Dashboard
+
+Cortex includes a visual dashboard with a knowledge graph, memory cards, insights, and a 3D brain view.
 
 ```bash
-git clone https://github.com/mkdelta221/claude-cortex.git
-cd claude-cortex
-npm install
-npm run build
+# Start the dashboard
+npx claude-cortex --dashboard
 ```
 
-### 2. Configure Claude Code
+- **Dashboard**: http://localhost:3030
+- **API**: http://localhost:3001
 
-**Option A: Project-scoped (recommended for testing)**
+### Auto-start on login
+
+```bash
+npx claude-cortex service install    # Enable
+npx claude-cortex service uninstall  # Disable
+npx claude-cortex service status     # Check
+```
+
+Works on **macOS** (launchd), **Linux** (systemd), and **Windows** (Startup folder).
+
+### Dashboard Views
+
+- **Graph** — 2D knowledge graph with zoom-responsive labels and animated links
+- **Memories** — Browseable card grid with sort, filter, and bulk actions
+- **Insights** — Activity heatmap, knowledge coverage, memory quality analysis
+- **Brain** — 3D neural network visualization
+
+### Memory Colors
+
+| Color | Category |
+|-------|----------|
+| Blue | Architecture |
+| Purple | Pattern |
+| Green | Preference |
+| Red | Error |
+| Yellow | Learning |
+| Cyan | Context |
+
+## CLI Reference
+
+```bash
+npx claude-cortex setup              # Configure Claude Code + hooks + Clawdbot
+npx claude-cortex setup --with-stop-hook  # Also install real-time Stop hook
+npx claude-cortex doctor             # Check installation health
+npx claude-cortex --dashboard        # Start dashboard + API
+npx claude-cortex --version          # Show version
+npx claude-cortex hook pre-compact   # Run hook manually
+npx claude-cortex hook session-start
+npx claude-cortex hook session-end
+npx claude-cortex hook stop
+npx claude-cortex service install    # Auto-start dashboard on login
+npx claude-cortex clawdbot install   # Install Clawdbot/Moltbot hook
+npx claude-cortex clawdbot status    # Check Clawdbot hook status
+```
+
+## Advanced Configuration
+
+<details>
+<summary>Alternative install methods</summary>
+
+### Use with npx (no global install)
 
 Create `.mcp.json` in your project directory:
 
@@ -62,15 +178,23 @@ Create `.mcp.json` in your project directory:
 }
 ```
 
-**Option B: Global (all projects)**
+For global config, create `~/.claude/.mcp.json` with the same content.
 
-Create `~/.claude/.mcp.json` with the same content.
+### Install from source
 
-After adding the config, restart Claude Code and approve the MCP server when prompted.
+```bash
+git clone https://github.com/mkdelta221/claude-cortex.git
+cd claude-cortex
+npm install
+npm run build
+```
 
-### 3. Configure Hooks (Recommended)
+</details>
 
-Add to `~/.claude/settings.json` for automatic memory extraction and context loading:
+<details>
+<summary>Manual hook configuration</summary>
+
+If you prefer to configure hooks manually instead of using `npx claude-cortex setup`, add to `~/.claude/settings.json`:
 
 ```json
 {
@@ -112,185 +236,18 @@ Add to `~/.claude/settings.json` for automatic memory extraction and context loa
 }
 ```
 
-- **PreCompact**: Auto-saves important context before compaction events
-- **SessionStart**: Auto-loads project context at the start of each session
-- **SessionEnd**: Auto-saves context when the session exits
+</details>
 
-### 4. Run Setup (Recommended)
+<details>
+<summary>Custom database location</summary>
+
+Default: `~/.claude-cortex/memories.db`
 
 ```bash
-npx claude-cortex setup
+npx claude-cortex --db /path/to/custom.db
 ```
 
-This configures everything automatically:
-- **Claude Code**: Adds proactive memory instructions to `~/.claude/CLAUDE.md`
-- **Hooks**: Installs PreCompact, SessionStart, and SessionEnd hooks into `~/.claude/settings.json`
-- **Clawdbot/Moltbot**: Installs `cortex-memory` hook if Clawdbot or Moltbot is detected
-
-Safe to run multiple times (idempotent).
-
-**Optional: Stop hook** — Checks the last response for notable content and prompts Claude to `remember`:
-```bash
-npx claude-cortex setup --with-stop-hook
-```
-The Stop hook uses local pattern matching (no API cost). Loop prevention is programmatic.
-
-### 5. Use It
-
-The memory system integrates seamlessly with Claude Code. Here are the key tools:
-
-#### Remember Something
-```
-Claude, remember that we're using PostgreSQL for the database.
-```
-
-#### Recall Information
-```
-Claude, what do you know about our database setup?
-```
-
-#### Get Context (Key for Compaction!)
-```
-Claude, get the context for this project.
-```
-
-## Tools
-
-| Tool | Description |
-|------|-------------|
-| `remember` | Store a memory with auto-categorization and salience detection |
-| `recall` | Search and retrieve memories (semantic search, filters) |
-| `forget` | Delete memories (single or bulk, with safety confirmations) |
-| `get_context` | **THE KEY TOOL** - Get relevant context, especially after compaction |
-| `start_session` | Start a session, get project context |
-| `end_session` | End session, trigger consolidation |
-| `consolidate` | Run memory consolidation manually |
-| `memory_stats` | View memory statistics |
-| `export_memories` | Export as JSON for backup |
-| `import_memories` | Import from JSON |
-
-## Resources
-
-The server also exposes MCP resources:
-
-| Resource | Description |
-|----------|-------------|
-| `memory://context` | Current memory context summary |
-| `memory://important` | High-priority memories |
-| `memory://recent` | Recently accessed memories |
-
-## How It Works
-
-### Salience Detection
-
-Not everything is worth remembering. The system scores information on:
-
-| Factor | Weight | Example |
-|--------|--------|---------|
-| Explicit request | 1.0 | "Remember this" |
-| Architecture decision | 0.9 | "We're using microservices" |
-| Error resolution | 0.8 | "Fixed by updating X" |
-| Code pattern | 0.7 | "Use this approach for auth" |
-| User preference | 0.7 | "Always use strict mode" |
-| Code references | 0.5 | Mentions specific files/functions |
-| Emotional markers | 0.5 | "Important", "critical" |
-
-### Temporal Decay
-
-Like human memory:
-
-```
-score = base_salience × (0.995 ^ hours_since_access)
-```
-
-- **Decay**: Memories fade over time
-- **Reinforcement**: Each access boosts score by 1.2×
-- **Consolidation**: Frequently accessed short-term → long-term
-
-### Memory Types
-
-| Type | Decay Rate | Use Case |
-|------|------------|----------|
-| Short-term | Fast (hourly) | Current session, debugging |
-| Long-term | Slow (daily) | Architecture, patterns |
-| Episodic | Medium | Specific events, learnings |
-
-## Solving the Compaction Problem
-
-When Claude Code compacts context:
-
-1. **Before compaction** - The PreCompact hook **automatically extracts** important content
-2. **After compaction** - Claude is directed to call `get_context` automatically to restore context
-
-### Automatic Memory Extraction (PreCompact Hook)
-
-The system includes a hook that runs before every context compaction:
-
-```
-🧠 AUTO-MEMORY: 3 important items were automatically saved before compaction.
-IMPORTANT: You MUST call the 'get_context' MCP tool NOW to restore your project knowledge.
-```
-
-**What gets auto-extracted:**
-- Decisions: "decided to...", "going with...", "chose..."
-- Error fixes: "fixed by...", "the solution was...", "root cause..."
-- Learnings: "learned that...", "discovered...", "turns out..."
-- Architecture: "the architecture uses...", "design pattern..."
-- Preferences: "always...", "never...", "prefer to..."
-- Important notes: "important:", "remember:", "key point..."
-
-Auto-extracted memories are:
-- Tagged with `auto-extracted` for easy filtering
-- Scored using salience detection (only high-scoring items saved)
-- Limited to 5 per compaction to avoid noise
-
-### Example Workflow
-
-```
-# Session starts
-Claude: Let me get the project context.
-[Calls get_context tool]
-> Found: PostgreSQL database, React frontend, auth uses JWT...
-
-# Work happens, context grows...
-
-# Compaction occurs, context is lost!
-
-# You notice Claude forgot something:
-You: Claude, what database are we using?
-Claude: Let me check my memory.
-[Calls recall tool with query "database"]
-> Found: "Using PostgreSQL for the database" (architecture, 95% salience)
-```
-
-## Hook Coverage
-
-Claude Cortex uses three hooks to cover the full session lifecycle:
-
-| Hook | Fires When | What It Does | Reliability |
-|------|-----------|--------------|-------------|
-| **SessionStart** | Session begins | Loads project context from memory | Reliable |
-| **PreCompact** | Before context compaction | Extracts important content before context is lost | Reliable (primary safety net) |
-| **SessionEnd** | Session terminates | Extracts important content on exit | Best-effort* |
-
-*SessionEnd does not fire on forced termination (terminal killed, SSH drops, crash). PreCompact remains the primary safety net since compaction happens more frequently than session exits.
-
-### Stop Hook (Opt-in, Future)
-
-A prompt-based Stop hook that uses Haiku to evaluate each Claude response for important events is planned. This calls the Haiku API on every response, which adds latency and cost. It will be opt-in via `--with-stop-hook` flag.
-
-## Configuration
-
-### Database Location
-
-Default: `~/.claude-cortex/memories.db` (with fallback to legacy `~/.claude-memory/` for existing users)
-
-Custom location:
-```bash
-node dist/index.js --db /path/to/custom.db
-```
-
-Or in Claude config:
+Or in MCP config:
 ```json
 {
   "mcpServers": {
@@ -302,14 +259,20 @@ Or in Claude config:
 }
 ```
 
-### Environment Variables
+</details>
+
+<details>
+<summary>Environment variables</summary>
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3001` | API server port |
-| `CORTEX_CORS_ORIGINS` | `http://localhost:3030,http://localhost:3000` | Comma-separated allowed CORS origins. Set to `*` is not supported — add specific origins. |
+| `CORTEX_CORS_ORIGINS` | `localhost:3030,localhost:3000` | Comma-separated allowed CORS origins |
 
-### Tuning Parameters
+</details>
+
+<details>
+<summary>Tuning parameters</summary>
 
 In `src/memory/types.ts`:
 
@@ -325,121 +288,57 @@ export const DEFAULT_CONFIG = {
 };
 ```
 
-## Development
+</details>
+
+## Clawdbot / Moltbot Integration
+
+Cortex works with [Clawdbot](https://github.com/clawdbot/clawdbot) and [Moltbot](https://github.com/moltbot/moltbot) via [mcporter](https://mcpmarket.com/tools/skills/mcporter).
 
 ```bash
-# Install dependencies
-npm install
-
-# Development mode (with tsx)
-npm run dev
-
-# Build
-npm run build
-
-# Watch mode
-npm run watch
-```
-
-## Dashboard (Optional)
-
-The dashboard provides a 3D brain visualization of your memories with real-time updates.
-
-### CLI Commands
-
-```bash
-npx claude-cortex setup              # Configure Claude Code + Clawdbot (if detected)
-npx claude-cortex hook pre-compact   # Run pre-compact hook (for settings.json)
-npx claude-cortex hook session-start # Run session-start hook (for settings.json)
-npx claude-cortex service install    # Enable auto-start on login
-npx claude-cortex service uninstall  # Remove auto-start
-npx claude-cortex service status     # Check service status
-npx claude-cortex clawdbot install   # Install Clawdbot/Moltbot hook manually
-npx claude-cortex clawdbot uninstall # Remove Clawdbot/Moltbot hook
-npx claude-cortex clawdbot status    # Check Clawdbot hook status
-npx claude-cortex doctor             # Check installation health
-npx claude-cortex --version          # Show version
-```
-
-Works on **macOS** (launchd), **Linux** (systemd), and **Windows** (Startup folder). The dashboard and API server will start automatically on login.
-
-### Manual Start
-
-```bash
-# Terminal 1: Start API server
-npm run dev:api
-
-# Terminal 2: Start dashboard
-cd dashboard && npm run dev
-```
-
-- **Dashboard**: http://localhost:3030
-- **API Server**: http://localhost:3001
-
-### Features
-
-- **3D Brain Visualization** - Memories displayed as nodes in a neural network
-- **Search** - Full-text search with autocomplete suggestions
-- **Filters** - Filter by memory type (STM/LTM/Episodic) and category
-- **Statistics** - System health, memory counts, category distribution
-- **Controls** - Pause/resume memory creation, trigger consolidation
-- **Version Management** - Check for updates, update, and restart server
-
-### Memory Visualization Colors
-
-| Color | Category |
-|-------|----------|
-| Blue | Architecture |
-| Purple | Pattern |
-| Green | Preference |
-| Red | Error |
-| Yellow | Learning |
-| Cyan | Context |
-
-## Moltbot / ClawdBot Integration
-
-Claude Cortex works with [Moltbot](https://github.com/moltbot/moltbot) (formerly ClawdBot) via [mcporter](https://mcpmarket.com/tools/skills/mcporter).
-
-### Automatic Hook (Recommended)
-
-```bash
+# Automatic (recommended)
 npx claude-cortex clawdbot install
+# Or: npx claude-cortex setup (auto-detects Clawdbot/Moltbot)
 ```
-
-Or run `npx claude-cortex setup` — it installs the hook automatically if Clawdbot/Moltbot is detected.
 
 The **cortex-memory** hook provides:
 - **Auto-save on `/new`** — Extracts decisions, fixes, learnings from ending sessions
 - **Context injection on bootstrap** — Agent starts with past session knowledge
-- **Keyword triggers** — Say "remember this" or "don't forget" to save with critical importance
+- **Keyword triggers** — Say "remember this" or "don't forget" to save explicitly
 
-### Manual mcporter Commands
-
-Since Claude Cortex is a standard MCP server, Moltbot can also call its tools directly:
+### Manual mcporter usage
 
 ```bash
-# Remember something via Moltbot
-npx mcporter call --stdio "npx -y claude-cortex" memory.remember title:"API uses JWT" content:"The auth system uses JWT tokens with 15-min expiry"
-
-# Recall memories
-npx mcporter call --stdio "npx -y claude-cortex" memory.recall query:"authentication"
-
-# Get project context
-npx mcporter call --stdio "npx -y claude-cortex" memory.get_context
+npx mcporter call --stdio "npx -y claude-cortex" remember title:"API uses JWT" content:"Auth uses JWT with 15-min expiry"
+npx mcporter call --stdio "npx -y claude-cortex" recall query:"authentication"
+npx mcporter call --stdio "npx -y claude-cortex" get_context
 ```
 
-**Shared memory**: Memories created via Moltbot are instantly available in Claude Code sessions and vice versa — both use the same SQLite database at `~/.claude-cortex/memories.db`.
+Memories are shared between Claude Code and Clawdbot — same SQLite database.
 
-## How This Differs from Other Solutions
+## How This Differs
 
 | Feature | Claude Cortex | Other MCP Memory Tools |
 |---------|---------------|------------------------|
-| Salience detection | ✅ Auto-detects importance | ❌ Manual only |
+| Automatic extraction | ✅ Hooks save context for you | ❌ Manual only |
+| Salience detection | ✅ Auto-detects importance | ❌ Everything is equal |
 | Temporal decay | ✅ Memories fade naturally | ❌ Static storage |
 | Consolidation | ✅ STM → LTM promotion | ❌ Flat storage |
-| Context injection | ✅ `get_context` tool | ❌ Manual recall |
-| Semantic search | ✅ FTS5 full-text | Varies |
-| Episodic memory | ✅ Event/pattern storage | ❌ Usually missing |
+| Context injection | ✅ Auto-loads on session start | ❌ Manual recall |
+| Knowledge graph | ✅ Visual dashboard | ❌ Usually missing |
+
+## Troubleshooting
+
+**Cortex isn't remembering anything automatically**
+→ Did you run `npx claude-cortex setup`? This installs the hooks that make memory automatic. Run `npx claude-cortex doctor` to verify.
+
+**Dashboard doesn't load**
+→ Run `npx claude-cortex doctor` to check status. The dashboard requires a one-time build — if it fails, try `cd $(npm root -g)/claude-cortex/dashboard && npm install && npm run build`.
+
+**Memories show 0 in the dashboard**
+→ Memories are created during compaction and session events. Use Claude Code for a while — memories build up naturally over time. You can also manually save with the `remember` tool.
+
+**"No cortex entry found in .mcp.json"**
+→ Create `.mcp.json` in your project root (see Advanced Configuration) or run `npx claude-cortex setup` to configure automatically.
 
 ## Support
 


### PR DESCRIPTION
## What

Restructures the README so the happy path is impossible to miss.

## Why

User feedback on Reddit: *"you have to keep telling it to remember things"* — because `setup` was buried at step 4 and most users never ran it.

## Changes

- **Quick Start is now 3 steps:** install → `setup` → restart. Done.
- **`setup` moved from step 4 to step 2** — the critical step that installs automatic hooks
- **"That's it" callout** — immediately tells users memory is now automatic
- **Manual hook JSON** moved to collapsible Advanced Configuration (was cluttering the happy path)
- **Alternative install methods** collapsed into `<details>` blocks
- **Troubleshooting section** added — addresses the exact complaints from Reddit
- **How It Works** moved up — explains hooks fire automatically before diving into tools
- **Dashboard section** simplified with clear start command
- **CLI Reference** consolidated into one block

## Result

Before: 5 steps with 3 options each, manual JSON config shown before the automated setup command
After: 3 steps, works out of the box, advanced config available but not in the way